### PR TITLE
Deploy master to AWS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,30 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/ruby:2-node
+    steps:
+      - checkout
+      - run:
+          name: Install aws
+          command: sudo apt-get install -y awscli
+      - run:
+          name: Install ruby descriptions
+          command: bundle install
+      - run:
+          name: Install node dependencies
+          command: npm install
+      - run:
+          name: Build
+          command: npm run build
+      - deploy:
+          command: |
+            if [ "${CIRCLE_BRANCH}" == "master" ];
+            then aws s3 sync dist s3://tech-action-working-group/ --delete --exclude "node_modules/*" --exclude "sass/*" --exclude ".git/*";
+            else echo "no deploy";
+            fi
+workflows:
+  version: 2
+  deploy:
+    jobs:
+      - build

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,0 @@
-test:
-  override:
-    - echo "no tests :)"


### PR DESCRIPTION
To make it fast & easy to keep this site up to date (and to close #2), this deploys the site to S3 on every `master` commit like merges.

Current CloudFront distribution URL is https://d6bn6xyagidmj.cloudfront.net/